### PR TITLE
Corrige cópia de saldos no fechamento do mês

### DIFF
--- a/FechaMes.bas
+++ b/FechaMes.bas
@@ -289,7 +289,8 @@ Private Sub CopiarSaldosCarteira(intPrimeiraLinhaResumo As Integer, intUltimaLin
           End If
           .Cells(intLinhaDestino, intColunaDescricao).Value = wsPlanilhaAtual.Cells(intCont, intColunaDescricao).Value
           If wsPlanilhaAtual.Cells(intCont, intColunaSaldoFinal).HasFormula And _
-             wsPlanilhaAtual.Cells(intCont, intColunaSaldoInicial).HasFormula Then
+             wsPlanilhaAtual.Cells(intCont, intColunaSaldoInicial).HasFormula And _
+             InStr(wsPlanilhaAtual.Cells(intCont, intColunaSaldoInicial).Formula, "D") > 0 Then
             If (intLinhaDestino = intCont) Then
               .Cells(intLinhaDestino, intColunaSaldoInicial).Formula = wsPlanilhaAtual.Cells(intCont, intColunaSaldoInicial).Formula
             Else


### PR DESCRIPTION
Quando a fórmula inicial e final da movimentação de um investimento não continha células relativas mas sim
uma soma simples, os valores iniciais e finais eram copiados para planilha destino no lugar de copiar apenas
os valores finais como inicial e final no destino.

Foi alterado o critério para identificar se existe uma letra "D" na fórmula, relativa a coluna que identificar o
investimento.