### PR TITLE
Corrige range que determina se planilha está fechada

### DIFF
--- a/Constants.bas
+++ b/Constants.bas
@@ -17,6 +17,9 @@ Public Const RANGE_CELULA_FIM_ADHOC As String = "C91"
 Public Const RANGE_CELULA_INICIO_PORTFOLIO As String = "C38"
 Public Const RANGE_CELULA_FIM_PORTFOLIO As String = "C77"
 
+' Planilha Retorno
+Public Const RANGE_PLAN_FECHADA = "retPlanFechada"
+
 ' Planilha Retrato
 Public Const RANGE_RELAT_RETRAT = "$A$1:$Q$175"
 
@@ -141,7 +144,7 @@ Public Const RANGE_COLUNA_SALDO_INICIAL_OURO As String = "F323:F332"
 Public Const RANGE_COLUNA_SALDO_FINAL_OURO As String = "N323:N332"
 Public Const RANGE_COLUNA_RESULTADO_COMUM_OURO As String = "X323:X332"
 
-' Carteira Alternativo
+' Carteira Cripto
 Public Const RANGE_COLUNA_DATA_ALTERNATIVO As String = "D339:D348"
 Public Const RANGE_COLUNA_ATIVO_ALTERNATIVO As String = "E339:E348"
 Public Const RANGE_COLUNA_QTDE_ALTERNATIVO As String = "G339:G348"

--- a/Relatorio.bas
+++ b/Relatorio.bas
@@ -162,7 +162,7 @@ Sub GerarRelatRetrato()
   Const XL_PORTRAIT As Integer = 1 ' retrato
   ' define o nome do PDF
   'MsgBox RetornarFileName()
-  monthNumber = Month(DateValue(Range("planFechada").Value & " 1"))
+  monthNumber = Month(DateValue(Range(RANGE_PLAN_FECHADA).Value & " 1"))
   If (Len(monthNumber) < 2) Then
     monthNumber = "0" & monthNumber
   End If
@@ -281,4 +281,3 @@ InvalidFileName:
   'O nome do arquivo é inválido
   ValidFileName = False
 End Function
-


### PR DESCRIPTION
Com a mudança no nome dos ranges, a planilha retrato estava apresentando um erro no momento de determinar o mês da planilha fechada.

Foi corrigido o nome do range e colocado como constante.