### PR TITLE
Corrige erro catastrófico

### DIFF
--- a/Relatorio.bas
+++ b/Relatorio.bas
@@ -154,15 +154,14 @@ Sub GerarRelatRetrato()
   '
   On Error GoTo erroRelatRetrato
   
-  Dim fileName As String
-  Dim dirFile As String
+  Dim fileName As String, dirFile As String, monthNumber As String, mesFechado As String
   Dim uniqueName As Boolean
   Dim userAnswer As VbMsgBoxResult
-  Dim monthNumber As String
   Const XL_PORTRAIT As Integer = 1 ' retrato
   ' define o nome do PDF
   'MsgBox RetornarFileName()
-  monthNumber = Month(DateValue(Range(RANGE_PLAN_FECHADA).Value & " 1"))
+  mesFechado = Range(RANGE_PLAN_FECHADA).Value
+  monthNumber = Month(DateValue(mesFechado & " 1"))
   If (Len(monthNumber) < 2) Then
     monthNumber = "0" & monthNumber
   End If


### PR DESCRIPTION
Ao abrir a planilha, os códigos VBA não estavam mais funcionando. Caso tentasse acionar algum método a planilha apresentava um erro de sistema <https://learn.microsoft.com/pt-br/office/vba/Language/Reference/User-Interface-Help/system-error-item> que impedia o seu funcionamento.

Esse erro era causado pelo uso de um range nomeado dentro de outra função.

Foi separado o valor do range nomeado para uma variável para evitar o erro acima.