### PR TITLE
Ajustes para nova tributação de investimento no exterior

### DIFF
--- a/Constants.bas
+++ b/Constants.bas
@@ -164,13 +164,13 @@ Public Const RANGE_CELULA_DOLAR_BACEN_COMPRA As String = "F371"
 Public Const RANGE_CELULA_DOLAR_BACEN_VENDA As String = "G371"
 
 ' Planilha Acoes
-Public Const RANGE_TAB_ACOES_365 As String = "B7:J136"
-Public Const RANGE_TAB_MOEDAS_365 As String = "C141:D143"
-Public Const RANGE_COLUNA_TICKETS As String = "E7:E136"
-Public Const RANGE_COLUNA_PRECO As String = "G7:G136"
-Public Const RANGE_CELULA_DOLAR As String = "D141"
-Public Const RANGE_CELULA_BTC As String = "D142"
-Public Const RANGE_CELULA_ETH As String = "D143"
+Public Const RANGE_TAB_ACOES_365 As String = "B7:J146"
+Public Const RANGE_COLUNA_TICKETS As String = "E7:E146"
+Public Const RANGE_COLUNA_PRECO As String = "G7:G146"
+Public Const RANGE_TAB_MOEDAS_365 As String = "C151:D153"
+Public Const RANGE_CELULA_DOLAR As String = "D151"
+Public Const RANGE_CELULA_BTC As String = "D152"
+Public Const RANGE_CELULA_ETH As String = "D153"
 
 ' Planilha TesouroDireto
 Public Const RANGE_DATA_ATUALIZ_TD = "H2"

--- a/EstaPasta_de_trabalho.cls
+++ b/EstaPasta_de_trabalho.cls
@@ -98,12 +98,7 @@ Private Sub Workbook_SheetChange(ByVal Sh As Object, ByVal Target As Range)
   ' testa se alterou os valores finais de ações, opções ou fii's
   If Not Application.Intersect(Target, Range(RANGE_COLUNA_SALDO_FINAL_ACOES)) Is Nothing Or _
      Not Application.Intersect(Target, Range(RANGE_COLUNA_SALDO_FINAL_FII)) Is Nothing Or _
-     Not Application.Intersect(Target, Range(RANGE_COLUNA_SALDO_FINAL_ETF)) Is Nothing Or _
-     Not Application.Intersect(Target, Range(RANGE_COLUNA_SALDO_FINAL_STOCK)) Is Nothing Or _
-     Not Application.Intersect(Target, Range(RANGE_COLUNA_SALDO_FINAL_REIT)) Is Nothing Or _
-     Not Application.Intersect(Target, Range(RANGE_COLUNA_SALDO_FINAL_TREASURY)) Is Nothing Or _
-     Not Application.Intersect(Target, Range(RANGE_COLUNA_SALDO_FINAL_OURO)) Is Nothing Or _
-     Not Application.Intersect(Target, Range(RANGE_COLUNA_SALDO_FINAL_CRIPTO)) Is Nothing Then
+     Not Application.Intersect(Target, Range(RANGE_COLUNA_SALDO_FINAL_ETF)) Is Nothing Then
     ' testa se gerou imposto a pagar
     If Target.Count = 1 And Not IsEmpty(Target) Then
       boolIgnoraAgenda = Range(RANGE_CELULA_IGNORA_AGENDA_CRIPTO).Value
@@ -251,3 +246,4 @@ Private Sub Workbook_BeforeClose(cancel As Boolean)
   wsPlanilhaAtual.Activate
   Application.ScreenUpdating = True
 End Sub
+


### PR DESCRIPTION
Devido a mudanças nas regras de tributação para investimentos no exterior, foi necessário adaptar as rotinas automáticas de agendamento de pagamento de tributos na planilha.